### PR TITLE
fix(sync): avoid symlink loops

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -1,20 +1,23 @@
 import { join, resolve } from 'path';
-import { readdir, stat } from 'fs';
+import { lstat, readdir, realpath } from 'fs';
 import { promisify } from 'util';
 
-const toStats = promisify(stat);
-const toRead = promisify(readdir);
+const real = promisify(realpath);
+const toStats = promisify(lstat);
+const list = promisify(readdir);
 
-export async function totalist(dir, callback, pre='') {
-	dir = resolve('.', dir);
-	await toRead(dir).then(arr => {
+export async function totalist(dir, callback, prefix, cache) {
+	cache = cache || new Set;
+	cache.add(dir = resolve('.', dir));
+
+	await list(dir).then(arr => {
 		return Promise.all(
 			arr.map(str => {
 				let abs = join(dir, str);
-				return toStats(abs).then(stats => {
-					return stats.isDirectory()
-						? totalist(abs, callback, join(pre, str))
-						: callback(join(pre, str), abs, stats)
+				return toStats(abs).then(async stats => {
+					return stats.isDirectory() && (!stats.isSymbolicLink() || !cache.has(await real(abs)))
+						? totalist(abs, callback, join(prefix || '', str))
+						: callback(join(prefix || '', str), abs, stats)
 				});
 			})
 		);

--- a/src/async.js
+++ b/src/async.js
@@ -18,7 +18,7 @@ export async function totalist(dir, callback, prefix, cache) {
 				let abs = join(dir, str);
 				return toStats(abs).then(stats => {
 					return stats.isDirectory()
-						? totalist(abs, callback, join(prefix || '', str))
+						? totalist(abs, callback, join(prefix || '', str), cache)
 						: callback(join(prefix || '', str), abs, stats)
 				});
 			})

--- a/src/async.js
+++ b/src/async.js
@@ -8,14 +8,16 @@ const list = promisify(readdir);
 
 export async function totalist(dir, callback, prefix, cache) {
 	cache = cache || new Set;
-	cache.add(dir = resolve('.', dir));
+	dir = await real(resolve('.', dir));
+	if (cache.has(dir)) return;
 
+	cache.add(dir);
 	await list(dir).then(arr => {
 		return Promise.all(
 			arr.map(str => {
 				let abs = join(dir, str);
-				return toStats(abs).then(async stats => {
-					return stats.isDirectory() && (!stats.isSymbolicLink() || !cache.has(await real(abs)))
+				return toStats(abs).then(stats => {
+					return stats.isDirectory()
 						? totalist(abs, callback, join(prefix || '', str))
 						: callback(join(prefix || '', str), abs, stats)
 				});

--- a/src/sync.d.ts
+++ b/src/sync.d.ts
@@ -1,3 +1,3 @@
 import { Stats } from 'fs';
 export type Caller = (relPath: string, absPath: string, stats: Stats) => any;
-export function totalist(dir: string, callback: Caller, prefix?: string): void;
+export function totalist(dir: string, callback: Caller, prefix?: string, cache?: Set<string>): void;

--- a/src/sync.js
+++ b/src/sync.js
@@ -2,16 +2,17 @@ import { join, resolve } from 'path';
 import { lstatSync, readdirSync, realpathSync } from 'fs';
 
 export function totalist(dir, callback, prefix, cache) {
-	prefix = prefix || '';
 	cache = cache || new Set;
-	cache.add(dir = resolve('.', dir));
-
-	let i=0, abs, stats;
-	let arr = readdirSync(dir);
-	for (; i < arr.length; i++) {
-		stats = lstatSync(abs = join(dir, arr[i]));
-		stats.isDirectory() && (!stats.isSymbolicLink() || !cache.has(realpathSync(abs)))
-			? totalist(abs, callback, join(prefix, arr[i]), cache)
-			: callback(join(prefix, arr[i]), abs, stats);
+	dir = realpathSync(resolve('.', dir));
+	if (!cache.has(dir)) {
+		cache.add(dir);
+		let i=0, abs, stats;
+		let arr = readdirSync(dir);
+		for (; i < arr.length; i++) {
+			stats = lstatSync(abs = join(dir, arr[i]));
+			stats.isDirectory()
+				? totalist(abs, callback, join(prefix || '', arr[i]), cache)
+				: callback(join(prefix || '', arr[i]), abs, stats);
+		}
 	}
 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,15 +1,17 @@
 import { join, resolve } from 'path';
-import { readdirSync, statSync } from 'fs';
+import { readdirSync, statSync, realpathSync } from 'fs';
 
-export function totalist(dir, callback, pre='') {
+export function totalist(dir, callback, pre='', chain=[]) {
 	dir = resolve('.', dir);
-	let arr = readdirSync(dir);
+	let link = realpathSync.native(dir);
+	if (chain.includes(link)) return;
+	let arr = readdirSync(link);
 	let i=0, abs, stats;
 	for (; i < arr.length; i++) {
 		abs = join(dir, arr[i]);
 		stats = statSync(abs);
 		stats.isDirectory()
-			? totalist(abs, callback, join(pre, arr[i]))
+			? totalist(abs, callback, join(pre, arr[i]), chain.concat(link))
 			: callback(join(pre, arr[i]), abs, stats);
 	}
 }

--- a/test/async.js
+++ b/test/async.js
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { join, normalize } from 'path';
@@ -49,6 +50,34 @@ test('(async) usage :: absolute', async () => {
 
 	assert.equal(scripts.sort(), ['aaa/index.js', 'bbb/ccc/index.js', 'bbb/index.js'].map(normalize).sort(), 'script `name` values are expected');
 	assert.equal(styles.sort(), ['aaa/index.css', 'bbb/ccc/index.css', 'bbb/index.css'].map(normalize).sort(), 'style `name` values are expected');
+});
+
+
+test('usage :: symbolic directory', async () => {
+	let symlink = join(fixtures, 'symlink');
+	fs.symlinkSync(fixtures, symlink);
+
+	try {
+		let count = 0;
+		let items = {};
+
+		await totalist(fixtures, (name, abs, stats) => {
+			count++;
+			assert.not(stats.isDirectory(), 'file is not a directory');
+			assert.ok(abs.startsWith(fixtures), '~> `abs` is absolute');
+			assert.not(name.startsWith(fixtures), '~> `name` is NOT absolute');
+			assert.is(stats.isSymbolicLink(), abs === symlink);
+
+			items[abs] = (items[abs] || 0) + 1;
+		});
+
+		const keys = Object.keys(items);
+		assert.is(count, 7, 'saw 7 files total');
+		assert.is(keys.length, 7, '~> unique file paths');
+		assert.ok(keys.every(k => items[k] === 1), '~> saw each item once');
+	} finally {
+		fs.unlinkSync(symlink);
+	}
 });
 
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { join, normalize } from 'path';
@@ -48,6 +49,34 @@ test('usage :: absolute', () => {
 
 	assert.equal(scripts, ['aaa/index.js', 'bbb/ccc/index.js', 'bbb/index.js'].map(normalize), 'script `name` values are expected');
 	assert.equal(styles, ['aaa/index.css', 'bbb/ccc/index.css', 'bbb/index.css'].map(normalize), 'style `name` values are expected');
+});
+
+
+test('usage :: symbolic directory', () => {
+	let symlink = join(fixtures, 'symlink');
+	fs.symlinkSync(fixtures, symlink);
+
+	try {
+		let count = 0;
+		let items = {};
+
+		totalist(fixtures, (name, abs, stats) => {
+			count++;
+			assert.not(stats.isDirectory(), 'file is not a directory');
+			assert.ok(abs.startsWith(fixtures), '~> `abs` is absolute');
+			assert.not(name.startsWith(fixtures), '~> `name` is NOT absolute');
+			assert.is(stats.isSymbolicLink(), abs === symlink);
+
+			items[abs] = (items[abs] || 0) + 1;
+		});
+
+		const keys = Object.keys(items);
+		assert.is(count, 7, 'saw 7 files total');
+		assert.is(keys.length, 7, '~> unique file paths');
+		assert.ok(keys.every(k => items[k] === 1), '~> saw each item once');
+	} finally {
+		fs.unlinkSync(symlink);
+	}
 });
 
 


### PR DESCRIPTION
Check the chain of directories that led to the current directory before reading its contents. Avoid reading the same directory twice when crawling deeper.

The `realpathSync` result is never passed to the callback, so all file paths are still inside the root directory.

**Note:** Only the sync version is fixed by this PR. The async version is not used by `sirv`, so I can't justify helping there.