### PR TITLE
Support importing totalist/sync from es modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,12 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
       "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./sync": {
-      "require": "./sync/index.js",
       "import": "./sync/index.mjs",
-      "default": "./sync/index.js"
+      "require": "./sync/index.js"
     }
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,18 @@
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.js"
+    },
+    "./sync": {
+      "require": "./sync/index.js",
+      "import": "./sync/index.mjs",
+      "default": "./sync/index.js"
+    }
+  },
   "license": "MIT",
   "files": [
     "index.d.ts",


### PR DESCRIPTION
Currently when I'm trying to import `totalist/sync` from
es module in node I get this error

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '.../node_modules/totalist/sync' is not supported resolving ES modules imported from my-script.js
Did you mean to import totalist/sync/index.js?
```

Exports field will help to fix this.