### PR TITLE
fix(types): add a `types` condition to the `exports` manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./sync": {
+      "types": "./sync/index.d.ts",
       "import": "./sync/index.mjs",
       "require": "./sync/index.js"
     }


### PR DESCRIPTION
This is required with all of the new "modern" `moduleResolution`s in TypeScript. `package.json#exports` becomes the **only** source of information about the package so when those `moduleResolution`s are used and when a package has `exports` then top-level `package.json#types` are simply ignored.

cc @TrySound 